### PR TITLE
Remove duplication between GemcombineFile and GmosaicFile

### DIFF
--- a/gempy/gemini/eti/atlistutils.py
+++ b/gempy/gemini/eti/atlistutils.py
@@ -1,0 +1,38 @@
+
+from gempy.gemini import gemini_tools
+
+from ..utils import logutils
+log = logutils.get_logger(__name__)
+
+class AtListUtils:
+
+	def __init__(self):
+		log.debug("AtListUtils __init__")
+
+	def prepare_adinput(self, adinput, prefix, diskinlist, taskname):
+		for ad in adinput:
+            ad = gemini_tools.obsmode_add(ad)
+            origname = ad.filename
+            ad.update_filename(prefix=prefix, strip=True)
+            diskinlist.append(ad.filename)
+            log.fullinfo("Temporary image (%s) on disk for the IRAF task %s" % \
+                          (ad.filename, taskname))
+            ad.write(ad.filename, overwrite=True)
+            ad.filename = origname
+
+    def prepare_atlist(self, atlist, pid_task, diskinlist, taskname):
+        atlist = "tmpImageList" + pid_task
+        fhdl = open(atlist, "w")
+        for fil in diskinlist:
+            fhdl.writelines(fil + "\n")
+        fhdl.close()
+        log.fullinfo("Temporary list (%s) on disk for the IRAF task %s" % \
+                      (atlist, taskname))
+
+    def remove_files(self, filelist, atlist):
+    	log.debug("AtListUtils remove_files()")
+    	for a_file in filelist:
+            os.remove(a_file)
+            log.fullinfo("%s was deleted from disk" % a_file)
+        os.remove(atlist)
+        log.fullinfo("%s was deleted from disk" % atlist)

--- a/gempy/gemini/eti/atlistutils.py
+++ b/gempy/gemini/eti/atlistutils.py
@@ -1,4 +1,3 @@
-
 from gempy.gemini import gemini_tools
 
 from ..utils import logutils
@@ -6,11 +5,11 @@ log = logutils.get_logger(__name__)
 
 class AtListUtils:
 
-	def __init__(self):
-		log.debug("AtListUtils __init__")
+    def __init__(self):
+        log.debug("AtListUtils __init__")
 
-	def prepare_adinput(self, adinput, prefix, diskinlist, taskname):
-		for ad in adinput:
+    def prepare_adinput(self, adinput, prefix, diskinlist, taskname):
+        for ad in adinput:
             ad = gemini_tools.obsmode_add(ad)
             origname = ad.filename
             ad.update_filename(prefix=prefix, strip=True)

--- a/gempy/gemini/eti/atlistutils.py
+++ b/gempy/gemini/eti/atlistutils.py
@@ -29,8 +29,8 @@ class AtListUtils:
                       (atlist, taskname))
 
     def remove_files(self, filelist, atlist):
-    	log.debug("AtListUtils remove_files()")
-    	for a_file in filelist:
+        log.debug("AtListUtils remove_files()")
+        for a_file in filelist:
             os.remove(a_file)
             log.fullinfo("%s was deleted from disk" % a_file)
         os.remove(atlist)

--- a/gempy/gemini/eti/gmosaicfile.py
+++ b/gempy/gemini/eti/gmosaicfile.py
@@ -6,6 +6,7 @@ import astrodata
 import gemini_instruments
 from gempy.utils import logutils
 from gempy.eti_core.pyrafetifile import PyrafETIFile
+from gempy.eti_core.atlistutils import AtListUtils
 
 from gempy.gemini import gemini_tools
 
@@ -57,34 +58,17 @@ class InAtList(GmosaicFile):
         log.debug("InAtList __init__")
         GmosaicFile.__init__(self, inputs, params, ad)
         self.atlist = ""
+        self.atlistutils = AtListUtils()
 
     def prepare(self):
         log.debug("InAtList prepare()")
-        for ad in self.adinput:
-            ad = gemini_tools.obsmode_add(ad)
-            origname = ad.filename
-            ad.update_filename(prefix=self.get_prefix(), strip=True)
-            self.diskinlist.append(ad.filename)
-            log.fullinfo("Temporary image (%s) on disk for the IRAF task %s" % \
-                          (ad.filename, self.taskname))
-            ad.write(ad.filename, overwrite=True)
-            ad.filename = origname
-        self.atlist = "tmpImageList" + self.pid_task
-        fhdl = open(self.atlist, "w")
-        for fil in self.diskinlist:
-            fhdl.writelines(fil + "\n")
-        fhdl.close()
-        log.fullinfo("Temporary list (%s) on disk for the IRAF task %s" % \
-                      (self.atlist, self.taskname))
+        self.atlistutils.prepare_adinput(self.adinput, self.get_prefix(), self.diskinlist, self.taskname)
+        self.atlistutils.prepare_atlist(self.atlist, self.pid_task, self.diskinlist, self.taskname)
         self.filedict.update({"inimages": "@" + self.atlist})
 
     def clean(self):
         log.debug("InAtList clean()")
-        for a_file in self.diskinlist:
-            os.remove(a_file)
-            log.fullinfo("%s was deleted from disk" % a_file)
-        os.remove(self.atlist)
-        log.fullinfo("%s was deleted from disk" % self.atlist)
+        self.atlistutils.remove_files(self.diskinlist, self.atlist)
 
 class OutAtList(GmosaicFile):
     inputs = None
@@ -105,6 +89,7 @@ class OutAtList(GmosaicFile):
         self.suffix = params["suffix"]
         self.ad_name = []
         self.atlist = ""
+        self.atlistutils = AtListUtils()
 
     def prepare(self):
         log.debug("OutAtList prepare()")
@@ -136,11 +121,7 @@ class OutAtList(GmosaicFile):
 
     def clean(self):
         log.debug("OutAtList clean()")
-        for tmpname in self.diskoutlist:
-            os.remove(tmpname)
-            log.fullinfo(tmpname + " was deleted from disk")
-        os.remove(self.atlist)
-        log.fullinfo(self.atlist + " was deleted from disk")
+        self.atlistutils.remove_files(self.diskoutlist, self.atlist)
 
 
 class LogFile(GmosaicFile):


### PR DESCRIPTION
Through the use of CodeClimate's Quality static analysis tool I was able to identify duplicate code in GemcombineFile and GmosaicFile. Within the corresponding InAtList classes for each file, the clean method was identical and the prepare methods were identical except for the last line. 

This refactoring is an attempt to remove this duplicate code without adding too much extra complexity. I think this approach of using a new AtListUtils class accomplishes this well. I also considered putting this code in the base class PyrafETIFile and calling the methods via super, but this would result in the base class having knowledge of its grandchildren subclasses, which isn't good. Additionally I considered leveraging Python's multiple inheritance feature, but in this case I think it is more appropriate to go with a "having a" vs. an "is a" relationship.

I'm not able to fully run the tests associated with gemcombine and gmosaic due to not having the testdata needed to execute these tests. This should be done before this code is put into use and/or tests should be written that exercises AtListUtils directly.